### PR TITLE
hw/i8042: Fix value may be used uninitialized in function kbd_io

### DIFF
--- a/hw/i8042.c
+++ b/hw/i8042.c
@@ -295,7 +295,7 @@ static void kbd_reset(void)
 static void kbd_io(struct kvm_cpu *vcpu, u64 addr, u8 *data, u32 len,
 		   u8 is_write, void *ptr)
 {
-	u8 value;
+	u8 value = 0;
 
 	if (is_write)
 		value = ioport__read8(data);


### PR DESCRIPTION
#3 