### PR TITLE
Set initial value to fix gcc compile warning error.

### DIFF
--- a/hw/i8042.c
+++ b/hw/i8042.c
@@ -295,7 +295,7 @@ static void kbd_reset(void)
 static void kbd_io(struct kvm_cpu *vcpu, u64 addr, u8 *data, u32 len,
 		   u8 is_write, void *ptr)
 {
-	u8 value;
+	u8 value = 0;
 
 	if (is_write)
 		value = ioport__read8(data);


### PR DESCRIPTION
Fixes the following compilation issue:

hw/i8042.c: In function ‘kbd_io’:
hw/i8042.c:153:19: error: ‘value’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   state.write_cmd = val;
   ~~~~~~~~~~~~~~~~^~~~~
hw/i8042.c:298:5: note: ‘value’ was declared here
  u8 value;
     ^~~~~
cc1: all warnings being treated as errors

Signed-off-by: raoyunkun <yunkunrao@gmail.com>