### PR TITLE
i8042: fix off-by-one error in kbd_read_data()

### DIFF
--- a/hw/i8042.c
+++ b/hw/i8042.c
@@ -193,7 +193,7 @@ static u8 kbd_read_data(void)
 	} else {
 		i = state.kread - 1;
 		if (i < 0)
-			i = QUEUE_SIZE;
+			i = QUEUE_SIZE - 1;
 		ret = state.kq[i];
 	}
 	return ret;


### PR DESCRIPTION
When the keyboard queue is empty and kread is 0, the code incorrectly sets i to QUEUE_SIZE (128), causing an out-of-bounds access to kq[128]. Valid indices are 0..127.

Fix this by using QUEUE_SIZE - 1 for proper circular queue wrap-around.